### PR TITLE
fix: remove compilation errors for crate 'clap'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 **/*.rs.bk
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/patrickelectric/bridges"
 repository = "https://github.com/patrickelectric/bridges"
 keywords = ["cli", "serial", "udp"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -19,7 +19,7 @@ path = "src/main.rs"
 name = "bridges"
 
 [dependencies]
-clap = "3.0.0-beta.2"
+clap = { version = "3.0", features = ["derive"] }
 lazy_static = "1.4.0"
 serialport = "4.0"
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,8 @@
-use clap::{self, Clap};
+use clap::Parser;
 
 /// This doc string acts as a help message when the user runs '--help'
 /// as do all doc strings on fields
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap(version = env!("CARGO_PKG_VERSION"), author = env!("CARGO_PKG_AUTHORS"), about = "Does serial<->UDP bridges, for now.")]
 #[clap(setting = clap::AppSettings::ColoredHelp)]
 pub struct Options {


### PR DESCRIPTION
Removed compilation errors related to clap usage. Next PR will handle those related to unstable features.