### PR TITLE
Update serialport

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,4 @@ name = "bridges"
 clap = { version = "3.0", features = ["derive"] }
 hashbrown = "0.12"
 lazy_static = "1.4"
-serialport = "4.0"
+serialport = "4.3"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -46,6 +46,10 @@ pub struct Options {
         default_value = "0.0.0.0:9092"
     )]
     pub udp_address: String,
+
+    /// Sets a UDP port to be listened
+    #[clap(long = "--listen-port")]
+    pub udp_listen_port: Option<u16>,
 }
 
 #[derive(Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,8 @@ pub fn main() -> Result<(), std::io::Error> {
         });
 
     let socket_address = &cli::options().udp_address;
-    let socket = socket::new(&socket_address)
+    let listen_port = cli::options().udp_listen_port.unwrap_or(0);
+    let socket = socket::new(socket_address, listen_port)
         .unwrap_or_else(|error| panic!("Failed to bind address: {}", error));
 
     // Serial and socket are ready, time to run ABR

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -17,7 +17,7 @@ pub struct Socket {
     destiny_address: Option<String>,
 }
 
-pub fn new(address: &str) -> Result<Socket, std::io::Error> {
+pub fn new(address: &str, listen_port: u16) -> Result<Socket, std::io::Error> {
     // Connect as server or client
     let mut destiny_address = None;
     let ip_address = std::net::IpAddr::from_str(address.split(':').next().unwrap()).unwrap();
@@ -25,7 +25,7 @@ pub fn new(address: &str) -> Result<Socket, std::io::Error> {
         true => std::net::UdpSocket::bind(address).unwrap(),
         false => {
             destiny_address = Some(address.to_string());
-            std::net::UdpSocket::bind("0.0.0.0:0").unwrap()
+            std::net::UdpSocket::bind(format!("0.0.0.0:{listen_port}")).unwrap()
         }
     };
     log!("UDP Server: {}", socket.local_addr().unwrap());


### PR DESCRIPTION
This patch:
1. Updates the `serialport` dependency so the serial port is now exclusive, meaning we will not allow other processes to access the serial port we are using.
2. adds the option to configure the port to listen via a CLI argument `--listen-port`, defaulting to the previous behavior (using `0`, which is a random one).